### PR TITLE
Create Calls resource

### DIFF
--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -1,3 +1,4 @@
+mock
 twilio
 twisted
 treq

--- a/vumi_twilio_api/tests/test_twilio_api.py
+++ b/vumi_twilio_api/tests/test_twilio_api.py
@@ -180,7 +180,8 @@ class TestTwilioAPIServer(VumiTestCase):
         self.assertEqual(response.code, 400)
         content = yield response.content()
         root = ET.fromstring(content)
-        [error_message, error_type] = sorted(root, key=lambda c: c.tag)
+        [error] = list(root)
+        [error_message, error_type] = sorted(error, key=lambda c: c.tag)
         self.assertEqual(error_message.tag, 'error_message')
         self.assertEqual(
             error_message.text, "'foo' is not a valid request format")
@@ -382,13 +383,15 @@ class TestServerFormatting(TestCase):
     def test_format_json(self):
         format_json = TwilioAPIServer.format_json
         d = {
-            'Foo': {
-                'Bar': {
-                    'Baz': 'Qux',
+            'Root': {
+                'Foo': {
+                    'Bar': {
+                        'Baz': 'Qux',
+                    },
+                    'FooBar': 'BazQux',
                 },
-                'FooBar': 'BazQux',
-            },
-            'BarFoo': 'QuxBaz',
+                'BarFoo': 'QuxBaz',
+            }
         }
         res = format_json(d)
         root = json.loads(res)

--- a/vumi_twilio_api/tests/test_twilio_api.py
+++ b/vumi_twilio_api/tests/test_twilio_api.py
@@ -92,11 +92,11 @@ class TestTwilioAPIServer(VumiTestCase):
         self.assertEqual(name.tag, 'Name')
         self.assertEqual(name.text, 'v1')
         self.assertEqual(uri.tag, 'Uri')
-        self.assertEqual(uri.text, '/v1')
+        self.assertEqual(uri.text, '/v1.xml')
         self.assertEqual(subresourceuris.tag, 'SubresourceUris')
         [accounts] = sorted(list(subresourceuris), key=lambda i: i.tag)
         self.assertEqual(accounts.tag, 'Accounts')
-        self.assertEqual(accounts.text, '/v1/Accounts')
+        self.assertEqual(accounts.text, '/v1/Accounts.xml')
 
     @inlineCallbacks
     def test_root_json(self):
@@ -108,9 +108,9 @@ class TestTwilioAPIServer(VumiTestCase):
         content = yield response.json()
         self.assertEqual(content, {
             'name': 'v1',
-            'uri': '/v1',
+            'uri': '/v1.json',
             'subresource_uris': {
-                'accounts': '/v1/Accounts'
+                'accounts': '/v1/Accounts.json'
             }
         })
 

--- a/vumi_twilio_api/tests/test_twilio_api.py
+++ b/vumi_twilio_api/tests/test_twilio_api.py
@@ -64,7 +64,17 @@ class TestTwilioAPIServer(VumiTestCase):
         content = yield response.content()
         root = ET.fromstring(content)
         self.assertEqual(root.tag, "TwilioResponse")
-        self.assertEqual(list(root), [])
+        [version] = list(root)
+        self.assertEqual(version.tag, 'Version')
+        [name, subresourceuris, uri] = sorted(list(version), key=lambda i: i.tag)
+        self.assertEqual(name.tag, 'Name')
+        self.assertEqual(name.text, 'v1')
+        self.assertEqual(uri.tag, 'Uri')
+        self.assertEqual(uri.text, '/v1')
+        self.assertEqual(subresourceuris.tag, 'SubresourceUris')
+        [accounts] = sorted(list(subresourceuris), key=lambda i: i.tag)
+        self.assertEqual(accounts.tag, 'Accounts')
+        self.assertEqual(accounts.text, '/v1/Accounts')
 
     @inlineCallbacks
     def test_root_xml(self):
@@ -76,7 +86,17 @@ class TestTwilioAPIServer(VumiTestCase):
         content = yield response.content()
         root = ET.fromstring(content)
         self.assertEqual(root.tag, "TwilioResponse")
-        self.assertEqual(list(root), [])
+        [version] = list(root)
+        self.assertEqual(version.tag, 'Version')
+        [name, subresourceuris, uri] = sorted(list(version), key=lambda i: i.tag)
+        self.assertEqual(name.tag, 'Name')
+        self.assertEqual(name.text, 'v1')
+        self.assertEqual(uri.tag, 'Uri')
+        self.assertEqual(uri.text, '/v1')
+        self.assertEqual(subresourceuris.tag, 'SubresourceUris')
+        [accounts] = sorted(list(subresourceuris), key=lambda i: i.tag)
+        self.assertEqual(accounts.tag, 'Accounts')
+        self.assertEqual(accounts.text, '/v1/Accounts')
 
     @inlineCallbacks
     def test_root_json(self):
@@ -86,7 +106,13 @@ class TestTwilioAPIServer(VumiTestCase):
             ['application/json'])
         self.assertEqual(response.code, 200)
         content = yield response.json()
-        self.assertEqual(content, {})
+        self.assertEqual(content, {
+            'name': 'v1',
+            'uri': '/v1',
+            'subresource_uris': {
+                'accounts': '/v1/Accounts'
+            }
+        })
 
     @inlineCallbacks
     def test_root_invalid_format(self):

--- a/vumi_twilio_api/tests/test_twilio_api.py
+++ b/vumi_twilio_api/tests/test_twilio_api.py
@@ -107,14 +107,23 @@ class TestServerFormatting(TestCase):
     def test_format_json(self):
         format_json = TwilioAPIServer.format_json
         d = {
-            'foo': {
-                'bar': {
-                    'baz': 'qux',
+            'Foo': {
+                'Bar': {
+                    'Baz': 'Qux',
                 },
-                'foobar': 'bazqux',
+                'FooBar': 'BazQux',
             },
-            'barfoo': 'quxbaz',
+            'BarFoo': 'QuxBaz',
         }
         res = format_json(d)
         root = json.loads(res)
-        self.assertEqual(root, d)
+        expected = {
+            'foo': {
+                'bar': {
+                    'baz': 'Qux',
+                },
+                'foo_bar': 'BazQux',
+            },
+            'bar_foo': 'QuxBaz',
+        }
+        self.assertEqual(root, expected)

--- a/vumi_twilio_api/tests/test_twilio_api.py
+++ b/vumi_twilio_api/tests/test_twilio_api.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import json
 from klein import Klein
 from mock import Mock
+import re
 import treq
 from twilio.rest import TwilioRestClient
 from twilio.rest.exceptions import TwilioRestException
@@ -96,6 +97,9 @@ class TestTwilioAPIServer(VumiTestCase):
         url = 'http://%s:%s%s%s' % (addr.host, addr.port, '/twiml/', filename)
         return deferToThread(
             self.client.calls.create, *args, url=url, **kwargs)
+
+    def assertRegexpMatches(self, text, regexp, msg=None):
+        self.assertTrue(re.search(regexp, text), msg=msg)
 
     @inlineCallbacks
     def test_root_default(self):

--- a/vumi_twilio_api/tests/test_twilio_api.py
+++ b/vumi_twilio_api/tests/test_twilio_api.py
@@ -255,7 +255,7 @@ class TestTwilioAPIServer(VumiTestCase):
                 'From': '+12345', 'Url': url},
             error={
                 'error_type': 'UsageError',
-                'error_message': 
+                'error_message':
                     "Required field 'To' not supplied",
             })
 
@@ -271,7 +271,7 @@ class TestTwilioAPIServer(VumiTestCase):
                 'To': '+12345', 'Url': url},
             error={
                 'error_type': 'UsageError',
-                'error_message': 
+                'error_message':
                     "Required field 'From' not supplied",
             })
 
@@ -287,7 +287,7 @@ class TestTwilioAPIServer(VumiTestCase):
                 'To': '+12345', 'From': '+54321'},
             error={
                 'error_type': 'UsageError',
-                'error_message': 
+                'error_message':
                     "Request must have an 'Url' or an 'ApplicationSid' field",
             })
 

--- a/vumi_twilio_api/twilio_api.py
+++ b/vumi_twilio_api/twilio_api.py
@@ -203,8 +203,8 @@ class TwilioAPIServer(object):
                     'Required field %r not supplied' % field,
                     format_)
             fields[field] = value
-        fields['Url'] = self._get_field('Url')
-        fields['ApplicationSid'] = self._get_field('ApplicationSid')
+        fields['Url'] = self._get_field(request, 'Url')
+        fields['ApplicationSid'] = self._get_field(request, 'ApplicationSid')
         if not (fields['Url'] or fields['ApplicationSid']):
             raise TwilioAPIUsageException(
                 "Request must have an 'Url' or an 'ApplicationSid' field",
@@ -216,27 +216,28 @@ class TwilioAPIServer(object):
         https://www.twilio.com/docs/api/rest/making-calls#post-parameters-optional
         """
         fields = {}
-        fields['Method'] = self._get_field('Method', 'POST')
-        fields['FallbackUrl'] = self._get_field('FallbackUrl')
-        fields['FallbackMethod'] = self._get_field('FallbackMethod', 'POST')
-        fields['StatusCallback'] = self._get_field('StatusCallback')
+        fields['Method'] = self._get_field(request, 'Method', 'POST')
+        fields['FallbackUrl'] = self._get_field(request, 'FallbackUrl')
+        fields['FallbackMethod'] = self._get_field(request, 'FallbackMethod', 'POST')
+        fields['StatusCallback'] = self._get_field(request, 'StatusCallback')
         fields['StatusCallbackMethod'] = self._get_field(
-            'StatusCallbackMethod', 'POST')
-        fields['SendDigits'] = self._get_field('SendDigits')
+            request, 'StatusCallbackMethod', 'POST')
+        fields['SendDigits'] = self._get_field(request, 'SendDigits')
         if fields['SendDigits']:
             if not all(re.match('[0-9#*w]', c) for c in fields['SendDigits']):
                 raise TwilioAPIUsageException(
                     "SendDigits value %r is not valid. May only contain the "
                     "characters (0-9), '#', '*' and 'w'" % fields['SendDigits'],
                     format_)
-        fields['IfMachine'] = self._get_field('IfMachine')
+        fields['IfMachine'] = self._get_field(request, 'IfMachine')
         valid_fields_IfMachine = [None, 'Continue', 'Hangup']
         if fields['IfMachine'] not in valid_fields_IfMachine:
             raise TwilioAPIUsageException(
                 "IfMachine value must be one of %r" % valid_fields_IfMachine,
                 format_)
-        fields['Timeout'] = self._get_field('Timeout', 60)
-        fields['Record'] = self._get_field('Record', False)
+        fields['Timeout'] = self._get_field(request, 'Timeout', 60)
+        fields['Record'] = self._get_field(request, 'Record', False)
+        return fields
 
     def _validate_make_call_fields(self, request, format_):
         """Validates the fields sent to the request according to

--- a/vumi_twilio_api/twilio_api.py
+++ b/vumi_twilio_api/twilio_api.py
@@ -108,8 +108,7 @@ class TwilioAPIServer(object):
         """Validates the required fields as detailed by
         https://www.twilio.com/docs/api/rest/making-calls#post-parameters-required
         """
-        #TODO: Support 'ApplicationSid' parameter
-        required_fields = ['From', 'To', 'Url']
+        required_fields = ['From', 'To']
         fields = {}
         for field in required_fields:
             value = self._get_field(request, field)
@@ -118,6 +117,12 @@ class TwilioAPIServer(object):
                     'Required field %r not supplied' % field,
                     format_)
             fields[field] = value
+        fields['Url'] = self._get_field('Url')
+        fields['ApplicationSid'] = self._get_field('ApplicationSid')
+        if not (fields['Url'] or fields['ApplicationSid']):
+            raise TwilioAPIUsageException(
+                "Request must have an 'Url' or an 'ApplicationSid' field",
+                format_)
         return fields
 
     def _validate_make_call_optional_fields(self, request, format_):
@@ -140,7 +145,7 @@ class TwilioAPIServer(object):
                     format_)
         fields['IfMachine'] = self._get_field('IfMachine')
         valid_fields_IfMachine = [None, 'Continue', 'Hangup']
-        if not fields['IfMachine'] in valid_fields_IfMachine:
+        if fields['IfMachine'] not in valid_fields_IfMachine:
             raise TwilioAPIUsageException(
                 "IfMachine value must be one of %r" % valid_fields_IfMachine,
                 format_)

--- a/vumi_twilio_api/twilio_api.py
+++ b/vumi_twilio_api/twilio_api.py
@@ -98,7 +98,7 @@ class TwilioAPIServer(object):
         return json.dumps(convert_dict_keys(dct))
 
     def _format_response(self, request, dct, format_):
-        format_ = str(format_.lstrip('.').lower())
+        format_ = str(format_.lstrip('.').lower()) or 'xml'
         func = getattr(
             TwilioAPIServer, 'format_' + format_, None)
         if not func:
@@ -117,15 +117,15 @@ class TwilioAPIServer(object):
                 },
             failure.value.format_)
 
-    @app.route('/', defaults={'format_': 'xml'}, methods=['GET'])
+    @app.route('/', defaults={'format_': ''}, methods=['GET'])
     @app.route('/<string:format_>', methods=['GET'])
     def root(self, request, format_):
         ret = {
             'Version': {
                 'Name': self.version,
-                'Uri': '/%s' % self.version,
+                'Uri': '/%s%s' % (self.version, format_),
                 'SubresourceUris': {
-                    'Accounts': '/%s/Accounts' % self.version,
+                    'Accounts': '/%s/Accounts%s' % (self.version, format_),
                 },
             },
         }
@@ -133,7 +133,7 @@ class TwilioAPIServer(object):
 
     @app.route(
         '/Accounts/<string:account_sid>/Calls',
-        defaults={'format_': 'xml'},
+        defaults={'format_': ''},
         methods=['POST'])
     @app.route(
         '/Accounts/<string:account_sid>/Calls<string:format_>',
@@ -183,10 +183,10 @@ class TwilioAPIServer(object):
                 'ApiVersion': self.version,
                 'ForwardedFrom': None,
                 'CallerName': None,
-                'Uri': fields['Uri'],
+                'Uri': '%s%s' % (fields['Uri'], format_),
                 'SubresourceUris': {
-                    'Notifications': '%s/Notifications' % fields['Uri'],
-                    'Recordings': '%s/Recordings' % fields['Uri'],
+                    'Notifications': '%s/Notifications%s' % (fields['Uri'], format_),
+                    'Recordings': '%s/Recordings%s' % (fields['Uri'], format_),
                 }
             }
         }, format_))

--- a/vumi_twilio_api/twilio_api.py
+++ b/vumi_twilio_api/twilio_api.py
@@ -84,8 +84,10 @@ class TwilioAPIServer(object):
         if dct.get('Version'):
             dct = dct['Version']
         c2s = re.compile('(?!^)([A-Z+])')
+
         def camel_to_snake(string):
             return c2s.sub(r'_\1', string).lower()
+
         def convert_dict_keys(dct):
             res = {}
             for key, value in dct.iteritems():
@@ -142,16 +144,17 @@ class TwilioAPIServer(object):
     def make_call(self, request, account_sid, format_):
         """Making calls endpoint
         https://www.twilio.com/docs/api/rest/making-calls"""
-        #TODO: Support ApplicationSid field
-        #TODO: Support SendDigits field
-        #TODO: Support IfMachine field
-        #TODO: Support Timeout field
-        #TODO: Support Record field
+        # TODO: Support ApplicationSid field
+        # TODO: Support SendDigits field
+        # TODO: Support IfMachine field
+        # TODO: Support Timeout field
+        # TODO: Support Record field
         fields = self._validate_make_call_fields(request, format_)
         fields['AccountSid'] = account_sid
         fields['CallId'] = self._get_sid()
         fields['DateCreated'] = self._get_timestamp()
-        fields['Uri'] = '/%s/Accounts/%s/Calls/%s' % (self.version, account_sid, fields['CallId'])
+        fields['Uri'] = '/%s/Accounts/%s/Calls/%s' % (
+            self.version, account_sid, fields['CallId'])
         message = yield self.vumi_worker.send_to(
             fields['To'], '',
             from_addr=fields['From'],
@@ -185,7 +188,8 @@ class TwilioAPIServer(object):
                 'CallerName': None,
                 'Uri': '%s%s' % (fields['Uri'], format_),
                 'SubresourceUris': {
-                    'Notifications': '%s/Notifications%s' % (fields['Uri'], format_),
+                    'Notifications': '%s/Notifications%s' % (
+                        fields['Uri'], format_),
                     'Recordings': '%s/Recordings%s' % (fields['Uri'], format_),
                 }
             }
@@ -233,12 +237,13 @@ class TwilioAPIServer(object):
         for field in [
                 'FallbackUrl', 'StatusCallback', 'SendDigits', 'IfMachine']:
             fields[field] = self._get_field(request, field)
-                
+
         if fields['SendDigits']:
             if not all(re.match('[0-9#*w]', c) for c in fields['SendDigits']):
                 raise TwilioAPIUsageException(
                     "SendDigits value %r is not valid. May only contain the "
-                    "characters (0-9), '#', '*' and 'w'" % fields['SendDigits'],
+                    "characters (0-9), '#', '*' and 'w'" % (
+                        fields['SendDigits']),
                     format_)
 
         valid_fields_IfMachine = [None, 'Continue', 'Hangup']
@@ -252,7 +257,7 @@ class TwilioAPIServer(object):
     def _validate_make_call_fields(self, request, format_):
         """Validates the fields sent to the request according to
         https://www.twilio.com/docs/api/rest/making-calls"""
-        fields =  self._validate_make_call_required_fields(request, format_)
-        fields.update(self._validate_make_call_optional_fields(request, format_))
+        fields = self._validate_make_call_required_fields(request, format_)
+        fields.update(
+            self._validate_make_call_optional_fields(request, format_))
         return fields
-

--- a/vumi_twilio_api/twilio_api.py
+++ b/vumi_twilio_api/twilio_api.py
@@ -195,7 +195,7 @@ class TwilioAPIServer(object):
         return str(uuid.uuid4()).replace('-', '')
 
     def _get_timestamp(self):
-        return datetime.now(tzlocal()).strftime('%a, %d %v %y %H:%M:%S %z')
+        return datetime.now(tzlocal()).strftime('%a, %d %b %Y %H:%M:%S %z')
 
     def _get_field(self, request, field, default=None):
         return request.args.get(field, [default])[0]

--- a/vumi_twilio_api/twilio_api.py
+++ b/vumi_twilio_api/twilio_api.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from dateutil.tz import tzlocal
+from dateutil.tz import tzutc
 import json
 from klein import Klein
 import os
@@ -199,7 +199,7 @@ class TwilioAPIServer(object):
         return str(uuid.uuid4()).replace('-', '')
 
     def _get_timestamp(self):
-        return datetime.now(tzlocal()).strftime('%a, %d %b %Y %H:%M:%S %z')
+        return datetime.now(tzutc()).strftime('%a, %d %b %Y %H:%M:%S %z')
 
     def _get_field(self, request, field, default=None):
         return request.args.get(field, [default])[0]

--- a/vumi_twilio_api/twilio_api.py
+++ b/vumi_twilio_api/twilio_api.py
@@ -96,10 +96,7 @@ class TwilioAPIServer(object):
 
     @staticmethod
     def format_json(dct):
-        if dct.get('Call'):
-            dct = dct['Call']
-        if dct.get('Version'):
-            dct = dct['Version']
+        _, dct = dct.popitem()
         return json.dumps(convert_dict_keys(dct))
 
     def _format_response(self, request, dct, format_):
@@ -117,9 +114,11 @@ class TwilioAPIServer(object):
         request.setResponseCode(400)
         return self._format_response(
             request, {
-                'error_type': 'UsageError',
-                'error_message': failure.value.message
-                },
+                'Error': {
+                    'error_type': 'UsageError',
+                    'error_message': failure.value.message
+                }
+            },
             failure.value.format_)
 
     @app.route('/', defaults={'format_': ''}, methods=['GET'])

--- a/vumi_twilio_api/twilio_api.py
+++ b/vumi_twilio_api/twilio_api.py
@@ -63,7 +63,19 @@ class TwilioAPIServer(object):
 
     @staticmethod
     def format_json(dct):
-        return json.dumps(dct)
+        c2s = re.compile('(?!^)([A-Z+])')
+        def camel_to_snake(string):
+            return c2s.sub(r'_\1', string).lower()
+        def convert_dict_keys(dct):
+            res = {}
+            for key, value in dct.iteritems():
+                if isinstance(value, dict):
+                    res[camel_to_snake(key)] = convert_dict_keys(value)
+                else:
+                    res[camel_to_snake(key)] = value
+            return res
+
+        return json.dumps(convert_dict_keys(dct))
 
     def _format_response(self, request, dct, format_):
         format_ = str(format_.lstrip('.').lower())

--- a/vumi_twilio_api/twilio_api.py
+++ b/vumi_twilio_api/twilio_api.py
@@ -81,6 +81,8 @@ class TwilioAPIServer(object):
     def format_json(dct):
         if dct.get('Call'):
             dct = dct['Call']
+        if dct.get('Version'):
+            dct = dct['Version']
         c2s = re.compile('(?!^)([A-Z+])')
         def camel_to_snake(string):
             return c2s.sub(r'_\1', string).lower()
@@ -118,7 +120,15 @@ class TwilioAPIServer(object):
     @app.route('/', defaults={'format_': 'xml'}, methods=['GET'])
     @app.route('/<string:format_>', methods=['GET'])
     def root(self, request, format_):
-        ret = {}
+        ret = {
+            'Version': {
+                'Name': self.version,
+                'Uri': '/%s' % self.version,
+                'SubresourceUris': {
+                    'Accounts': '/%s/Accounts' % self.version,
+                },
+            },
+        }
         return self._format_response(request, ret, format_)
 
     @app.route(

--- a/vumi_twilio_api/twilio_api.py
+++ b/vumi_twilio_api/twilio_api.py
@@ -13,6 +13,23 @@ from vumi.message import TransportUserMessage
 import xml.etree.ElementTree as ET
 
 
+c2s = re.compile('(?!^)([A-Z+])')
+
+
+def camel_to_snake(string):
+    return c2s.sub(r'_\1', string).lower()
+
+
+def convert_dict_keys(dct):
+    res = {}
+    for key, value in dct.iteritems():
+        if isinstance(value, dict):
+            res[camel_to_snake(key)] = convert_dict_keys(value)
+        else:
+            res[camel_to_snake(key)] = value
+    return res
+
+
 class TwilioAPIConfig(ApplicationWorker.CONFIG_CLASS):
     """Config for the Twilio API worker"""
     web_path = ConfigText(
@@ -83,20 +100,6 @@ class TwilioAPIServer(object):
             dct = dct['Call']
         if dct.get('Version'):
             dct = dct['Version']
-        c2s = re.compile('(?!^)([A-Z+])')
-
-        def camel_to_snake(string):
-            return c2s.sub(r'_\1', string).lower()
-
-        def convert_dict_keys(dct):
-            res = {}
-            for key, value in dct.iteritems():
-                if isinstance(value, dict):
-                    res[camel_to_snake(key)] = convert_dict_keys(value)
-                else:
-                    res[camel_to_snake(key)] = value
-            return res
-
         return json.dumps(convert_dict_keys(dct))
 
     def _format_response(self, request, dct, format_):


### PR DESCRIPTION
Create the `Calls` resource which allows creating calls. Only create the `POST` root method, as this is the only method that will be used.
